### PR TITLE
Limit timeline awards

### DIFF
--- a/cpdb/data/constants.py
+++ b/cpdb/data/constants.py
@@ -152,7 +152,7 @@ MAJOR_AWARDS = [
 
 # awards types displayed on the timeline (all others are not)
 TIMELINE_AWARDS = [
-    # https://directives.chicagopolice.org/#directive/public/6398: section V A 
+    # https://directives.chicagopolice.org/#directive/public/6398: section V A
     "Superintendents Award Of Valor",
     "Superintendents Award Of Merit",
     "Honored Police Star",
@@ -171,10 +171,10 @@ TIMELINE_AWARDS = [
     "Top Gun Arrest Award",
     "Special Service Award",
     # section V B
-    "Department Commendation", 
+    "Department Commendation",
     "Life Saving Award",
-    "Police Officer Of The Month Award", 
-    "Chicago Police Leadership Award", 
+    "Police Officer Of The Month Award",
+    "Chicago Police Leadership Award",
     "Problem Solving Award",
     # formatted major awards
     "Carter Harrison",

--- a/cpdb/data/constants.py
+++ b/cpdb/data/constants.py
@@ -150,6 +150,45 @@ MAJOR_AWARDS = [
     "superintendent's award of merit",
 ]
 
+# awards types displayed on the timeline (all others are not)
+TIMELINE_AWARDS = [
+    # https://directives.chicagopolice.org/#directive/public/6398: section V A 
+    "Superintendents Award Of Valor",
+    "Superintendents Award Of Merit",
+    "Honored Police Star",
+    "Police Blue Star Award",
+    "Police Blue Shield Award",
+    "Superintendents Award Of Tactical Excellence",
+    "Thomas Wortham IV Military and Community Service Award",
+    "Paul R. Bauer Leadership Award",
+    "William Powers Leadership Award",
+    "Arnold Mireles Special Partner",
+    "Annual Bureau Award Of Recognition",
+    "Special Commendation",
+    "Excellence in Victim Service Award",
+    "Joint Operations Award",
+    "Unit Meritorious Performance Award",
+    "Top Gun Arrest Award",
+    "Special Service Award",
+    # section V B
+    "Department Commendation", 
+    "Life Saving Award",
+    "Police Officer Of The Month Award", 
+    "Chicago Police Leadership Award", 
+    "Problem Solving Award",
+    # formatted major awards
+    "Carter Harrison",
+    "Lambert Tree",
+    "Richard J. Daley Police Medal Of Honor",
+    "Police Medal",
+    "Hundred Club Of Cook County Medal Of Valor",
+
+
+
+
+
+]
+
 
 ALLEGATION_MIN_DATETIME = datetime.strptime(settings.ALLEGATION_MIN, '%Y-%m-%d').replace(tzinfo=pytz.utc)
 ALLEGATION_MAX_DATETIME = datetime.strptime(settings.ALLEGATION_MAX, '%Y-%m-%d').replace(tzinfo=pytz.utc)

--- a/cpdb/officers/queries.py
+++ b/cpdb/officers/queries.py
@@ -24,7 +24,7 @@ from officers.serializers.response_mobile_serializers import (
     LawsuitNewTimelineMobileSerializer,
 )
 
-from data.constants import TIMELINE_AWARDS, MAJOR_AWARDS
+from data.constants import TIMELINE_AWARDS
 
 
 class OfficerTimelineBaseQuery(object):

--- a/cpdb/officers/queries.py
+++ b/cpdb/officers/queries.py
@@ -24,6 +24,8 @@ from officers.serializers.response_mobile_serializers import (
     LawsuitNewTimelineMobileSerializer,
 )
 
+from data.constants import TIMELINE_AWARDS, MAJOR_AWARDS
+
 
 class OfficerTimelineBaseQuery(object):
     cr_new_timeline_serializer = None
@@ -131,7 +133,8 @@ class OfficerTimelineBaseQuery(object):
         award_timeline_queryset = self.officer.award_set.filter(
             Q(start_date__isnull=False),
             ~Q(award_type__contains='Honorable Mention'),
-            ~Q(award_type__in=['Complimentary Letter', 'Department Commendation'])
+            ~Q(award_type__in=['Complimentary Letter', 'Department Commendation']),
+            Q(award_type__in=TIMELINE_AWARDS)
         ).annotate(
             **self.unit_subqueries('start_date')
         ).annotate(


### PR DESCRIPTION
Description
-- 
Limits the awards that show up on the officer timeline to those covered in Sections V-A and V-B of the current CPD awards directive: https://directives.chicagopolice.org/#directive/public/6398
- Adds a TIMELINE_AWARDS constant listing award_types, uses it as a filter in queries

Relevant issues (Optional)
--
- Should look into whether we want to continue not showing Department Commendation (which is currently excluded, despite being in the above list) from the timeline, as well as complimentary letters and honorable mentions (which have their own counts that are cached to the officer profile)
